### PR TITLE
fix: comma issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2024-07-30
+- Fix comma issue:
+
+```shell
+383.413.710-30","role" -> parser -> 38341371030role
+This applies to all other mark characters like ";!?, etc)"
+```
+
 ## [0.2.2] - 2024-03-01
 - Fix quotes issue between matches
 

--- a/string_tester.go
+++ b/string_tester.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // StringTesterResult must sync with the DefaultRuleSet
@@ -117,13 +118,21 @@ func removePunctuation(text string) string {
 
 }
 
+// customFields splits a string into fields based on custom delimiters
+func customFields(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return unicode.IsSpace(r) || r == ',' || r == ';' || r == '!' || r == '?' || r == '(' || r == ')' ||
+			r == '[' || r == ']' || r == '{' || r == '}' || r == '"' || r == '\''
+	})
+}
+
 // AnonymizeFindings anonymizes all matches within the rules
 func (t *StringTester) AnonymizeFindings(s string) (string, bool) {
 	matched := false
 	hasFindings := false
 
 	for _, rule := range t.Rules {
-		for _, x := range strings.Fields(s) {
+		for _, x := range customFields(s) {
 			matched = rule.Filter(x)
 			if matched {
 				// Bugfix: if matched, we need to remove comma, dot or other common chars from the string

--- a/string_tester_test.go
+++ b/string_tester_test.go
@@ -204,6 +204,15 @@ func TestRedactCPF(t *testing.T) {
                  "messages": [{"role": "user", "content": "testing cpf leaking ,,,,111444777-351,,,,, abc"}],
                  "temperature": 0.1}'`,
 			false},
+		{`'{
+                 "model": "gpt-3.5-turbo",
+                 "messages": [{"content": "Say this: my cpf is 383.413.710-30"}"role": "user"}],
+                 "temperature": 0.1}'`,
+			`'{
+                 "model": "gpt-3.5-turbo",
+                 "messages": [{"content": "Say this: my cpf is ` + cpfRule.AnonymizeOptions.AnonymizeString + `"}"role": "user"}],
+                 "temperature": 0.1}'`,
+			true},
 	}
 
 	leakspokTester := NewStringTester(rules)
@@ -327,6 +336,16 @@ func TestRedactEmail(t *testing.T) {
                  "temperature": 0.1}'`,
 			false,
 		},
+		{`'{
+                 "model": "gpt-3.5-turbo",
+                 "messages": [{"role": "user", "content": "testing email leaking,joao.test@gmail.com "}],
+                 "temperature": 0.1}'`,
+			`'{
+                 "model": "gpt-3.5-turbo",
+                 "messages": [{"role": "user", "content": "testing email leaking,` + emailRule.AnonymizeOptions.AnonymizeString + ` "}],
+                 "temperature": 0.1}'`,
+			true,
+		},
 	}
 
 	leakspokTester := NewStringTester(rules)
@@ -434,6 +453,15 @@ func TestRedactIPAddress(t *testing.T) {
                  "messages": [{"role": "user", "content": "testing IP address leaking ,????????;;999.112.90.999,::????, abc"}],
                  "temperature": 0.1}'`,
 			false},
+		{`'{
+                 "model": "gpt-3.5-turbo",
+                 "messages": [{"role": "user", "content": "testing IP address leaking,180.112.90.22 abc"}],
+                 "temperature": 0.1}'`,
+			`'{
+                 "model": "gpt-3.5-turbo",
+                 "messages": [{"role": "user", "content": "testing IP address leaking,` + ipRule.AnonymizeOptions.AnonymizeString + ` abc"}],
+                 "temperature": 0.1}'`,
+			true},
 	}
 
 	leakspokTester := NewStringTester(rules)


### PR DESCRIPTION
Fix the comma issue problem:

```sh
curl -X POST https://xxxx/api/v1/proxy/openai/v1/chat/completions   -H "Content-Type: application/json"   -H "X-Requester-Token: $REQUESTER_TOKEN"   -H "X-Privacy-Filter: Enabled"   -d '{
     "model": "gpt-3.5-turbo",
     "messages": [{"content": "Say this: 383.413.710-30","role": "user"}],
     "temperature": 0.7
   }'
``` 

Issue:

 383.413.710-30","role" -> parser ->  38341371030role
 
This applies to all other mark characters like ";!?, etc)" 